### PR TITLE
github: set dependabot updates to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"


### PR DESCRIPTION
Update the existing Dependabot configuration so both Go modules and\nGitHub Actions are checked daily instead of weekly.\n\nThe repository already tracks the primary Go ecosystem and GitHub\nActions, and I did not find any other package manager manifests that\nneed additional Dependabot entries.

